### PR TITLE
Handle contract calls reverts properly

### DIFF
--- a/src/main/java/org/web3j/quorum/tx/ClientTransactionManager.java
+++ b/src/main/java/org/web3j/quorum/tx/ClientTransactionManager.java
@@ -19,11 +19,13 @@ import java.util.List;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.methods.request.Transaction;
+import org.web3j.protocol.core.methods.response.EthCall;
 import org.web3j.protocol.core.methods.response.EthGetCode;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.quorum.Quorum;
 import org.web3j.quorum.methods.request.PrivateTransaction;
 import org.web3j.tx.TransactionManager;
+import org.web3j.tx.ContractErrorUtil;
 
 /** TransactionManager implementation for using a Quorum node to transact. */
 public class ClientTransactionManager extends TransactionManager {
@@ -112,11 +114,12 @@ public class ClientTransactionManager extends TransactionManager {
     @Override
     public String sendCall(String to, String data, DefaultBlockParameter defaultBlockParameter)
             throws IOException {
-        return quorum.ethCall(
-                        Transaction.createEthCallTransaction(getFromAddress(), to, data),
-                        defaultBlockParameter)
-                .send()
-                .getValue();
+        EthCall ethCall = quorum.ethCall(
+                Transaction.createEthCallTransaction(getFromAddress(), to, data),
+                defaultBlockParameter)
+                .send();
+        ContractErrorUtil.assertCallNotReverted(ethCall);
+        return ethCall.getValue();
     }
 
     @Override

--- a/src/main/java/org/web3j/quorum/tx/ClientTransactionManager.java
+++ b/src/main/java/org/web3j/quorum/tx/ClientTransactionManager.java
@@ -24,8 +24,8 @@ import org.web3j.protocol.core.methods.response.EthGetCode;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.quorum.Quorum;
 import org.web3j.quorum.methods.request.PrivateTransaction;
-import org.web3j.tx.TransactionManager;
 import org.web3j.tx.ContractErrorUtil;
+import org.web3j.tx.TransactionManager;
 
 /** TransactionManager implementation for using a Quorum node to transact. */
 public class ClientTransactionManager extends TransactionManager {
@@ -114,10 +114,11 @@ public class ClientTransactionManager extends TransactionManager {
     @Override
     public String sendCall(String to, String data, DefaultBlockParameter defaultBlockParameter)
             throws IOException {
-        EthCall ethCall = quorum.ethCall(
-                Transaction.createEthCallTransaction(getFromAddress(), to, data),
-                defaultBlockParameter)
-                .send();
+        EthCall ethCall =
+                quorum.ethCall(
+                                Transaction.createEthCallTransaction(getFromAddress(), to, data),
+                                defaultBlockParameter)
+                        .send();
         ContractErrorUtil.assertCallNotReverted(ethCall);
         return ethCall.getValue();
     }

--- a/src/main/kotlin/org/web3j/tx/ContractErrorUtil.kt
+++ b/src/main/kotlin/org/web3j/tx/ContractErrorUtil.kt
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2020 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 @file:JvmName("ContractErrorUtil")
 
 package org.web3j.tx

--- a/src/main/kotlin/org/web3j/tx/ContractErrorUtil.kt
+++ b/src/main/kotlin/org/web3j/tx/ContractErrorUtil.kt
@@ -1,0 +1,7 @@
+@file:JvmName("ContractErrorUtil")
+
+package org.web3j.tx
+
+import org.web3j.protocol.core.methods.response.EthCall
+
+fun assertCallNotReverted(ethCall: EthCall) = TransactionManager.assertCallNotReverted(ethCall)


### PR DESCRIPTION
org.web3j.quorum.tx.ClientTransactionmanger now checks if contract call has been reverted and if so throws an informative 'ContractCallException' as implemented by org.web3j.tx.ClientTransactionmanger and org.web3j.tx.ReadonlyTransactionManager.