### PR TITLE
Feature/add privacy marker transactions

### DIFF
--- a/src/integration-test/java/org/web3j/quorum/TransactionRequestTest.java
+++ b/src/integration-test/java/org/web3j/quorum/TransactionRequestTest.java
@@ -120,4 +120,74 @@ public class TransactionRequestTest extends RequestTester {
         verifyResult(
                 "{\"jsonrpc\":\"2.0\",\"method\":\"eth_sendTransactionAsync\",\"params\":[{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
     }
+
+    @Test
+    public void testGetQuorumTransactionReceipt() throws Exception {
+        web3j.ethGetQuorumTransactionReceipt("0x").send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionReceipt\",\"params\":[\"0x\"],\"id\":1}");
+    }
+
+    @Test
+    public void testDistributePrivateTransactionWithMandatoryFor() throws Exception {
+        String signedTransactionData = "SignedTxData";
+        web3j.ethDistributePrivateTransaction(
+                        signedTransactionData,
+                        Arrays.asList("privateFor1", "privateFor2"),
+                        PrivacyFlag.MANDATORY_FOR,
+                        Arrays.asList("privateFor2"))
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"eth_distributePrivateTransaction\",\"params\":[\"SignedTxData\",{\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":2,\"mandatoryFor\":[\"privateFor2\"]}],\"id\":1}");
+    }
+
+    @Test
+    public void testDistributePrivateTransactionWithPrivacyFlag() throws Exception {
+        String signedTransactionData = "SignedTxData";
+        web3j.ethDistributePrivateTransaction(
+                        signedTransactionData,
+                        Arrays.asList("privateFor1", "privateFor2"),
+                        PrivacyFlag.PARTY_PROTECTION)
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"eth_distributePrivateTransaction\",\"params\":[\"SignedTxData\",{\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":1}],\"id\":1}");
+    }
+
+    @Test
+    public void testDistributePrivateTransaction() throws Exception {
+        String signedTransactionData = "SignedTxData";
+        web3j.ethDistributePrivateTransaction(
+                        signedTransactionData, Arrays.asList("privateFor1", "privateFor2"))
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"eth_distributePrivateTransaction\",\"params\":[\"SignedTxData\",{\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+    }
+
+    @Test
+    public void testGetPrivacyPrecompileAddress() throws Exception {
+        web3j.ethGetPrivacyPrecompileAddress().send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getPrivacyPrecompileAddress\",\"params\":[],\"id\":1}");
+    }
+
+    @Test
+    public void testGetPrivateTransactionByHash() throws Exception {
+        web3j.ethGetPrivateTransactionByHash("0x").send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getPrivateTransactionByHash\",\"params\":[\"0x\"],\"id\":1}");
+    }
+
+    @Test
+    public void testGetPrivateTransactionReceipt() throws Exception {
+        web3j.ethGetPrivateTransactionReceipt("0x").send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getPrivateTransactionReceipt\",\"params\":[\"0x\"],\"id\":1}");
+    }
 }

--- a/src/integration-test/java/org/web3j/quorum/TransactionResponseTest.java
+++ b/src/integration-test/java/org/web3j/quorum/TransactionResponseTest.java
@@ -12,6 +12,8 @@
  */
 package org.web3j.quorum;
 
+import java.math.BigInteger;
+
 import org.junit.jupiter.api.Test;
 
 import org.web3j.protocol.ResponseTester;
@@ -55,5 +57,36 @@ public class TransactionResponseTest extends ResponseTester {
 
         PrivatePayload privatePayload = deserialiseResponse(PrivatePayload.class);
         assertThat(privatePayload.getPrivatePayload(), is("0x"));
+    }
+
+    @Test
+    public void testGetQuorumTransactionReceipt() {
+        buildResponse(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"transactionHash\":\"0x0d9e7e34fd4db216a3f66981a467d9d990954e6ed3128aff4ec51a50fa175663\",\"transactionIndex\":\"0x0\",\"blockHash\":\"0xee5b9e9030d308c77a2d4f975b7090a026ac2cdfe9669e2452cedb4c82e8285e\",\"blockNumber\":\"0xc9e\",\"cumulativeGasUsed\":\"0x0\",\"gasUsed\":\"0x21c687\",\"contractAddress\":\"0x1932c48b2bf8102ba33b4a6b545c32236e342f34\",\"status\":\"0x1\",\"from\":\"0x0718197b9ac69127381ed0c4b5d0f724f857c4d1\",\"to\":\"0x8a5E2a6343108bABEd07899510fb42297938D41F\",\"logs\":[],\"logsBloom\":\"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",\"isPrivacyMarkerTransaction\":true}}");
+        EthGetQuorumTransactionReceipt ethQuorumReceipt =
+                (EthGetQuorumTransactionReceipt)
+                        this.deserialiseResponse(EthGetQuorumTransactionReceipt.class);
+
+        QuorumTransactionReceipt quorumReceipt = ethQuorumReceipt.getResult();
+        assertThat(
+                quorumReceipt.getTransactionHash(),
+                is("0x0d9e7e34fd4db216a3f66981a467d9d990954e6ed3128aff4ec51a50fa175663"));
+        assertThat(
+                quorumReceipt.getBlockHash(),
+                is("0xee5b9e9030d308c77a2d4f975b7090a026ac2cdfe9669e2452cedb4c82e8285e"));
+        assertThat(quorumReceipt.getBlockNumber(), is(BigInteger.valueOf(0xc9e)));
+        assertThat(quorumReceipt.getCumulativeGasUsed(), is(BigInteger.valueOf(0x0)));
+        assertThat(quorumReceipt.getGasUsed(), is(BigInteger.valueOf(0x21c687)));
+        assertThat(
+                quorumReceipt.getContractAddress(),
+                is("0x1932c48b2bf8102ba33b4a6b545c32236e342f34"));
+        assertThat(quorumReceipt.getStatus(), is("0x1"));
+        assertThat(quorumReceipt.getFrom(), is("0x0718197b9ac69127381ed0c4b5d0f724f857c4d1"));
+        assertThat(quorumReceipt.getTo(), is("0x8a5E2a6343108bABEd07899510fb42297938D41F"));
+        assertThat(
+                quorumReceipt.getLogsBloom(),
+                is(
+                        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
+        assertThat(quorumReceipt.getIsPrivacyMarkerTransaction(), is(true));
     }
 }

--- a/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
+++ b/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
@@ -20,11 +20,14 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.core.JsonRpc2_0Web3j;
 import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.response.EthGetTransactionReceipt;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
+import org.web3j.protocol.core.methods.response.EthTransaction;
 import org.web3j.quorum.methods.request.PrivateRawTransaction;
 import org.web3j.quorum.methods.request.PrivateTransaction;
 import org.web3j.quorum.methods.response.ConsensusNoResponse;
 import org.web3j.quorum.methods.response.ContractPrivacyMetadataInfo;
+import org.web3j.quorum.methods.response.EthAddress;
 import org.web3j.quorum.methods.response.PrivatePayload;
 import org.web3j.quorum.methods.response.istanbul.IstanbulBlockSigners;
 import org.web3j.quorum.methods.response.istanbul.IstanbulCandidates;
@@ -127,6 +130,58 @@ public class JsonRpc2_0Quorum extends JsonRpc2_0Web3j implements Quorum {
                 Collections.singletonList(transaction),
                 web3jService,
                 EthSendTransaction.class);
+    }
+
+    @Override
+    public Request<?, EthSendTransaction> ethDistributePrivateTransaction(
+            String signedTransactionData,
+            List<String> privateFor,
+            PrivacyFlag privacyFlag,
+            List<String> mandatoryFor) {
+        PrivateRawTransaction transaction =
+                new PrivateRawTransaction(privateFor, privacyFlag, mandatoryFor);
+        return new Request<>(
+                "eth_distributePrivateTransaction",
+                Arrays.asList(signedTransactionData, transaction),
+                web3jService,
+                EthSendTransaction.class);
+    }
+
+    @Override
+    public Request<?, EthSendTransaction> ethDistributePrivateTransaction(
+            String signedTransactionData, List<String> privateFor, PrivacyFlag privacyFlag) {
+        return ethDistributePrivateTransaction(
+                signedTransactionData, privateFor, privacyFlag, null);
+    }
+
+    @Override
+    public Request<?, EthSendTransaction> ethDistributePrivateTransaction(
+            String signedTransactionData, List<String> privateFor) {
+        return ethDistributePrivateTransaction(signedTransactionData, privateFor, null, null);
+    }
+
+    @Override
+    public Request<?, EthAddress> ethGetPrivacyPrecompileAddress() {
+        return new Request<>(
+                "eth_getPrivacyPrecompileAddress", Arrays.asList(), web3jService, EthAddress.class);
+    }
+
+    @Override
+    public Request<?, EthTransaction> ethGetPrivateTransactionByHash(String hexDigest) {
+        return new Request<>(
+                "eth_getPrivateTransactionByHash",
+                Collections.singletonList(hexDigest),
+                web3jService,
+                EthTransaction.class);
+    }
+
+    @Override
+    public Request<?, EthGetTransactionReceipt> ethGetPrivateTransactionReceipt(String hexDigest) {
+        return new Request<>(
+                "eth_getPrivateTransactionReceipt",
+                Collections.singletonList(hexDigest),
+                web3jService,
+                EthGetTransactionReceipt.class);
     }
 
     // raft consensus

--- a/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
+++ b/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
@@ -25,10 +25,7 @@ import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.protocol.core.methods.response.EthTransaction;
 import org.web3j.quorum.methods.request.PrivateRawTransaction;
 import org.web3j.quorum.methods.request.PrivateTransaction;
-import org.web3j.quorum.methods.response.ConsensusNoResponse;
-import org.web3j.quorum.methods.response.ContractPrivacyMetadataInfo;
-import org.web3j.quorum.methods.response.EthAddress;
-import org.web3j.quorum.methods.response.PrivatePayload;
+import org.web3j.quorum.methods.response.*;
 import org.web3j.quorum.methods.response.istanbul.IstanbulBlockSigners;
 import org.web3j.quorum.methods.response.istanbul.IstanbulCandidates;
 import org.web3j.quorum.methods.response.istanbul.IstanbulNodeAddress;
@@ -130,6 +127,37 @@ public class JsonRpc2_0Quorum extends JsonRpc2_0Web3j implements Quorum {
                 Collections.singletonList(transaction),
                 web3jService,
                 EthSendTransaction.class);
+    }
+
+    /*
+     * TODO: Remove override (just duplicated here so that I can check it's never called)
+     */
+    @Override
+    public Request<?, EthGetTransactionReceipt> ethGetTransactionReceipt(String transactionHash) {
+        System.out.printf(
+                "######### QuorumPollingTransactionReceiptProcessor::ethGetTransactionReceipt() PROBLEM - ethGetTransactionReceipt() should not be called!!\n");
+        return new Request<>(
+                "eth_getTransactionReceipt",
+                Arrays.asList(transactionHash),
+                web3jService,
+                EthGetTransactionReceipt.class);
+    }
+
+    @Override
+    public Request<?, EthGetQuorumTransactionReceipt> ethGetQuorumTransactionReceipt(
+            String transactionHash) {
+
+        // TODO: just return Request object, and remove the debug code below
+        Request<?, EthGetQuorumTransactionReceipt> request =
+                new Request(
+                        "eth_getTransactionReceipt",
+                        Arrays.asList(transactionHash),
+                        this.web3jService,
+                        EthGetQuorumTransactionReceipt.class);
+
+        System.out.printf(
+                "######### QuorumPollingTransactionReceiptProcessor::ethGetQuorumTransactionReceipt() Created EthGetQuorumTransactionReceipt request\n");
+        return request;
     }
 
     @Override

--- a/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
+++ b/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
@@ -129,35 +129,15 @@ public class JsonRpc2_0Quorum extends JsonRpc2_0Web3j implements Quorum {
                 EthSendTransaction.class);
     }
 
-    /*
-     * TODO: Remove override (just duplicated here so that I can check it's never called)
-     */
-    @Override
-    public Request<?, EthGetTransactionReceipt> ethGetTransactionReceipt(String transactionHash) {
-        System.out.printf(
-                "######### QuorumPollingTransactionReceiptProcessor::ethGetTransactionReceipt() PROBLEM - ethGetTransactionReceipt() should not be called!!\n");
-        return new Request<>(
-                "eth_getTransactionReceipt",
-                Arrays.asList(transactionHash),
-                web3jService,
-                EthGetTransactionReceipt.class);
-    }
-
     @Override
     public Request<?, EthGetQuorumTransactionReceipt> ethGetQuorumTransactionReceipt(
             String transactionHash) {
 
-        // TODO: just return Request object, and remove the debug code below
-        Request<?, EthGetQuorumTransactionReceipt> request =
-                new Request(
-                        "eth_getTransactionReceipt",
-                        Arrays.asList(transactionHash),
-                        this.web3jService,
-                        EthGetQuorumTransactionReceipt.class);
-
-        System.out.printf(
-                "######### QuorumPollingTransactionReceiptProcessor::ethGetQuorumTransactionReceipt() Created EthGetQuorumTransactionReceipt request\n");
-        return request;
+        return new Request(
+                "eth_getTransactionReceipt",
+                Arrays.asList(transactionHash),
+                this.web3jService,
+                EthGetQuorumTransactionReceipt.class);
     }
 
     @Override

--- a/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
+++ b/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
@@ -133,12 +133,14 @@ public class JsonRpc2_0Quorum extends JsonRpc2_0Web3j implements Quorum {
     public Request<?, EthGetQuorumTransactionReceipt> ethGetQuorumTransactionReceipt(
             String transactionHash) {
 
-        return new Request(
+        return new Request<>(
                 "eth_getTransactionReceipt",
                 Arrays.asList(transactionHash),
                 this.web3jService,
                 EthGetQuorumTransactionReceipt.class);
     }
+
+    // privacy marker transactions
 
     @Override
     public Request<?, EthSendTransaction> ethDistributePrivateTransaction(

--- a/src/main/java/org/web3j/quorum/Quorum.java
+++ b/src/main/java/org/web3j/quorum/Quorum.java
@@ -17,7 +17,9 @@ import java.util.List;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.response.EthGetTransactionReceipt;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
+import org.web3j.protocol.core.methods.response.EthTransaction;
 import org.web3j.quorum.methods.request.*;
 import org.web3j.quorum.methods.response.*;
 import org.web3j.quorum.methods.response.istanbul.IstanbulBlockSigners;
@@ -66,6 +68,24 @@ public interface Quorum extends Web3j {
             List<String> mandatoryFor);
 
     Request<?, EthSendTransaction> ethSendTransactionAsync(PrivateTransaction transaction);
+
+    Request<?, EthSendTransaction> ethDistributePrivateTransaction(
+            String signedTransactionData, List<String> privateFor);
+
+    Request<?, EthSendTransaction> ethDistributePrivateTransaction(
+            String signedTransactionData, List<String> privateFor, PrivacyFlag privacyFlag);
+
+    Request<?, EthSendTransaction> ethDistributePrivateTransaction(
+            String signedTransactionData,
+            List<String> privateFor,
+            PrivacyFlag privacyFlag,
+            List<String> mandatoryFor);
+
+    Request<?, EthAddress> ethGetPrivacyPrecompileAddress();
+
+    Request<?, EthTransaction> ethGetPrivateTransactionByHash(String hexDigest);
+
+    Request<?, EthGetTransactionReceipt> ethGetPrivateTransactionReceipt(String hexDigest);
 
     // raft consensus
 

--- a/src/main/java/org/web3j/quorum/Quorum.java
+++ b/src/main/java/org/web3j/quorum/Quorum.java
@@ -85,6 +85,8 @@ public interface Quorum extends Web3j {
 
     Request<?, EthTransaction> ethGetPrivateTransactionByHash(String hexDigest);
 
+    Request<?, EthGetQuorumTransactionReceipt> ethGetQuorumTransactionReceipt(String hexDigest);
+
     Request<?, EthGetTransactionReceipt> ethGetPrivateTransactionReceipt(String hexDigest);
 
     // raft consensus

--- a/src/main/java/org/web3j/quorum/Quorum.java
+++ b/src/main/java/org/web3j/quorum/Quorum.java
@@ -69,6 +69,10 @@ public interface Quorum extends Web3j {
 
     Request<?, EthSendTransaction> ethSendTransactionAsync(PrivateTransaction transaction);
 
+    Request<?, EthGetQuorumTransactionReceipt> ethGetQuorumTransactionReceipt(String hexDigest);
+
+    // privacy marker transactions
+
     Request<?, EthSendTransaction> ethDistributePrivateTransaction(
             String signedTransactionData, List<String> privateFor);
 
@@ -84,8 +88,6 @@ public interface Quorum extends Web3j {
     Request<?, EthAddress> ethGetPrivacyPrecompileAddress();
 
     Request<?, EthTransaction> ethGetPrivateTransactionByHash(String hexDigest);
-
-    Request<?, EthGetQuorumTransactionReceipt> ethGetQuorumTransactionReceipt(String hexDigest);
 
     Request<?, EthGetTransactionReceipt> ethGetPrivateTransactionReceipt(String hexDigest);
 

--- a/src/main/java/org/web3j/quorum/methods/response/EthAddress.java
+++ b/src/main/java/org/web3j/quorum/methods/response/EthAddress.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.quorum.methods.response;
+
+import org.web3j.protocol.core.Response;
+
+/** quorum_canonicalHash */
+public class EthAddress extends Response<String> {
+    public String getAddress() {
+        return getResult();
+    }
+}

--- a/src/main/java/org/web3j/quorum/methods/response/EthGetQuorumTransactionReceipt.java
+++ b/src/main/java/org/web3j/quorum/methods/response/EthGetQuorumTransactionReceipt.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.quorum.methods.response;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import org.web3j.protocol.ObjectMapperFactory;
+import org.web3j.protocol.core.Response;
+
+/** eth_getTransactionReceipt. */
+public class EthGetQuorumTransactionReceipt extends Response<QuorumTransactionReceipt> {
+
+    public Optional<QuorumTransactionReceipt> getTransactionReceipt() {
+        return Optional.ofNullable(getResult());
+    }
+
+    public static class ResponseDeserialiser extends JsonDeserializer<QuorumTransactionReceipt> {
+
+        private ObjectReader objectReader = ObjectMapperFactory.getObjectReader();
+
+        @Override
+        public QuorumTransactionReceipt deserialize(
+                JsonParser jsonParser, DeserializationContext deserializationContext)
+                throws IOException {
+            System.out.printf("######### EthGetQuorumTransactionReceipt::deserialize() ENTERED\n");
+            if (jsonParser.getCurrentToken() != JsonToken.VALUE_NULL) {
+                // TODO: restore the next line and remove the code below, added to facilitate
+                // debugging
+                // return objectReader.readValue(jsonParser, QuorumTransactionReceipt.class);
+                QuorumTransactionReceipt receipt =
+                        objectReader.readValue(jsonParser, QuorumTransactionReceipt.class);
+                System.out.printf(
+                        "######### EthGetQuorumTransactionReceipt::deserialize() Created QuorumTransactionReceipt: %s\n",
+                        receipt.toString());
+                return receipt;
+            } else {
+                return null; // null is wrapped by Optional in above getter
+            }
+        }
+    }
+}

--- a/src/main/java/org/web3j/quorum/methods/response/EthGetQuorumTransactionReceipt.java
+++ b/src/main/java/org/web3j/quorum/methods/response/EthGetQuorumTransactionReceipt.java
@@ -39,17 +39,8 @@ public class EthGetQuorumTransactionReceipt extends Response<QuorumTransactionRe
         public QuorumTransactionReceipt deserialize(
                 JsonParser jsonParser, DeserializationContext deserializationContext)
                 throws IOException {
-            System.out.printf("######### EthGetQuorumTransactionReceipt::deserialize() ENTERED\n");
             if (jsonParser.getCurrentToken() != JsonToken.VALUE_NULL) {
-                // TODO: restore the next line and remove the code below, added to facilitate
-                // debugging
-                // return objectReader.readValue(jsonParser, QuorumTransactionReceipt.class);
-                QuorumTransactionReceipt receipt =
-                        objectReader.readValue(jsonParser, QuorumTransactionReceipt.class);
-                System.out.printf(
-                        "######### EthGetQuorumTransactionReceipt::deserialize() Created QuorumTransactionReceipt: %s\n",
-                        receipt.toString());
-                return receipt;
+                return objectReader.readValue(jsonParser, QuorumTransactionReceipt.class);
             } else {
                 return null; // null is wrapped by Optional in above getter
             }

--- a/src/main/java/org/web3j/quorum/methods/response/QuorumTransactionReceipt.java
+++ b/src/main/java/org/web3j/quorum/methods/response/QuorumTransactionReceipt.java
@@ -63,12 +63,12 @@ public class QuorumTransactionReceipt extends TransactionReceipt {
         this.isPrivacyMarkerTransaction = isPrivacyMarkerTransaction;
     }
 
-    public Boolean getPrivacyMarkerTransaction() {
+    public Boolean getIsPrivacyMarkerTransaction() {
         return isPrivacyMarkerTransaction;
     }
 
-    public void setPrivacyMarkerTransaction(Boolean privacyMarkerTransaction) {
-        isPrivacyMarkerTransaction = privacyMarkerTransaction;
+    public void setIsPrivacyMarkerTransaction(Boolean isPrivacyMarkerTransaction) {
+        this.isPrivacyMarkerTransaction = isPrivacyMarkerTransaction;
     }
 
     public boolean isPrivacyMarkerTransaction() {

--- a/src/main/java/org/web3j/quorum/methods/response/QuorumTransactionReceipt.java
+++ b/src/main/java/org/web3j/quorum/methods/response/QuorumTransactionReceipt.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.quorum.methods.response;
+
+import java.util.List;
+
+import org.web3j.protocol.core.methods.response.Log;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+
+/**
+ * Quorum's Transaction Receipt object.
+ *
+ * <p>This is almost identical to the Ethereum {@link
+ * org.web3j.protocol.core.methods.response.TransactionReceipt} with the exception that it includes
+ * the isPrivacyMarkerTransaction field.
+ */
+public class QuorumTransactionReceipt extends TransactionReceipt {
+    private Boolean isPrivacyMarkerTransaction;
+
+    public QuorumTransactionReceipt() {}
+
+    public QuorumTransactionReceipt(
+            String transactionHash,
+            String transactionIndex,
+            String blockHash,
+            String blockNumber,
+            String cumulativeGasUsed,
+            String gasUsed,
+            String contractAddress,
+            String root,
+            String status,
+            String from,
+            String to,
+            List<Log> logs,
+            String logsBloom,
+            String revertReason,
+            Boolean isPrivacyMarkerTransaction) {
+        super(
+                transactionHash,
+                transactionIndex,
+                blockHash,
+                blockNumber,
+                cumulativeGasUsed,
+                gasUsed,
+                contractAddress,
+                root,
+                status,
+                from,
+                to,
+                logs,
+                logsBloom,
+                revertReason);
+        this.isPrivacyMarkerTransaction = isPrivacyMarkerTransaction;
+    }
+
+    public Boolean getPrivacyMarkerTransaction() {
+        return isPrivacyMarkerTransaction;
+    }
+
+    public void setPrivacyMarkerTransaction(Boolean privacyMarkerTransaction) {
+        isPrivacyMarkerTransaction = privacyMarkerTransaction;
+    }
+
+    public boolean isPrivacyMarkerTransaction() {
+        if (null != isPrivacyMarkerTransaction) {
+            return isPrivacyMarkerTransaction;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!super.equals(o)) {
+            return false;
+        }
+        if (!(o instanceof QuorumTransactionReceipt)) {
+            return false;
+        }
+
+        QuorumTransactionReceipt that = (QuorumTransactionReceipt) o;
+
+        return isPrivacyMarkerTransaction.equals(that);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result =
+                31 * result
+                        + (isPrivacyMarkerTransaction != null
+                                ? isPrivacyMarkerTransaction.hashCode()
+                                : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "QuorumTransactionReceipt{"
+                + "transactionHash='"
+                + super.getTransactionHash()
+                + '\''
+                + ", transactionIndex='"
+                + super.getTransactionIndex()
+                + '\''
+                + ", blockHash='"
+                + super.getBlockHash()
+                + '\''
+                + ", blockNumber='"
+                + super.getBlockNumber()
+                + '\''
+                + ", cumulativeGasUsed='"
+                + super.getCumulativeGasUsed()
+                + '\''
+                + ", gasUsed='"
+                + super.getGasUsed()
+                + '\''
+                + ", contractAddress='"
+                + super.getContractAddress()
+                + '\''
+                + ", root='"
+                + super.getRoot()
+                + '\''
+                + ", status='"
+                + super.getStatus()
+                + '\''
+                + ", from='"
+                + super.getFrom()
+                + '\''
+                + ", to='"
+                + super.getTo()
+                + '\''
+                + ", logs="
+                + super.getLogs()
+                + ", logsBloom='"
+                + super.getLogsBloom()
+                + '\''
+                + ", revertReason='"
+                + super.getRevertReason()
+                + '\''
+                + ", isPrivacyMarkerTransaction='"
+                + isPrivacyMarkerTransaction
+                + '\''
+                + '}';
+    }
+}

--- a/src/main/java/org/web3j/quorum/tx/response/QuorumPollingTransactionReceiptProcessor.java
+++ b/src/main/java/org/web3j/quorum/tx/response/QuorumPollingTransactionReceiptProcessor.java
@@ -88,14 +88,6 @@ public class QuorumPollingTransactionReceiptProcessor extends PollingTransaction
                     "Error processing request: " + transactionReceipt.getError().getMessage());
         }
 
-        // TODO: reinstate the next line and remove the code added below to faciliate debugging.
-        // return transactionReceipt.getTransactionReceipt();
-        Optional<? extends QuorumTransactionReceipt> receipt =
-                transactionReceipt.getTransactionReceipt();
-
-        System.out.printf(
-                "######### QuorumPollingTransactionReceiptProcessor::sendTransactionReceiptRequest() got receipt %s\n",
-                receipt.toString());
-        return receipt;
+        return transactionReceipt.getTransactionReceipt();
     }
 }

--- a/src/main/java/org/web3j/quorum/tx/response/QuorumPollingTransactionReceiptProcessor.java
+++ b/src/main/java/org/web3j/quorum/tx/response/QuorumPollingTransactionReceiptProcessor.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.quorum.tx.response;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.protocol.exceptions.TransactionException;
+import org.web3j.quorum.Quorum;
+import org.web3j.quorum.methods.response.EthGetQuorumTransactionReceipt;
+import org.web3j.quorum.methods.response.QuorumTransactionReceipt;
+import org.web3j.tx.response.PollingTransactionReceiptProcessor;
+
+/**
+ * Quorum's Transaction Receipt Processor object.
+ *
+ * <p>This is almost identical to the Ethereum {@link
+ * org.web3j.tx.response.PollingTransactionReceiptProcessor} with the exception that it returns a
+ * QuorumTransactionReceipt object. Note that this class currently pretty much replaces the
+ * superclass, as PollingTransactionReceiptProcessor doesn't really lend itself to reuse.
+ */
+public class QuorumPollingTransactionReceiptProcessor extends PollingTransactionReceiptProcessor {
+
+    private final Quorum quorum;
+
+    public QuorumPollingTransactionReceiptProcessor(
+            Quorum quorum, long sleepDuration, int attempts) {
+        super(quorum, sleepDuration, attempts);
+        this.quorum = quorum;
+    }
+
+    /*
+     * Returns QuorumTransactionReceipt.
+     */
+    @Override
+    public TransactionReceipt waitForTransactionReceipt(String transactionHash)
+            throws IOException, TransactionException {
+
+        return getQuorumTransactionReceipt(transactionHash, sleepDuration, attempts);
+    }
+
+    private QuorumTransactionReceipt getQuorumTransactionReceipt(
+            String transactionHash, long sleepDuration, int attempts)
+            throws IOException, TransactionException {
+
+        Optional<? extends QuorumTransactionReceipt> receiptOptional =
+                sendTransactionReceiptRequest(transactionHash);
+        for (int i = 0; i < attempts; i++) {
+            if (!receiptOptional.isPresent()) {
+                try {
+                    Thread.sleep(sleepDuration);
+                } catch (InterruptedException e) {
+                    throw new TransactionException(e);
+                }
+
+                receiptOptional = sendTransactionReceiptRequest(transactionHash);
+            } else {
+                return receiptOptional.get();
+            }
+        }
+
+        throw new TransactionException(
+                "Transaction receipt was not generated after "
+                        + ((sleepDuration * attempts) / 1000
+                                + " seconds for transaction: "
+                                + transactionHash),
+                transactionHash);
+    }
+
+    Optional<? extends QuorumTransactionReceipt> sendTransactionReceiptRequest(
+            String transactionHash) throws IOException, TransactionException {
+        EthGetQuorumTransactionReceipt transactionReceipt =
+                quorum.ethGetQuorumTransactionReceipt(transactionHash).send();
+
+        if (transactionReceipt.hasError()) {
+            throw new TransactionException(
+                    "Error processing request: " + transactionReceipt.getError().getMessage());
+        }
+
+        // TODO: reinstate the next line and remove the code added below to faciliate debugging.
+        // return transactionReceipt.getTransactionReceipt();
+        Optional<? extends QuorumTransactionReceipt> receipt =
+                transactionReceipt.getTransactionReceipt();
+
+        System.out.printf(
+                "######### QuorumPollingTransactionReceiptProcessor::sendTransactionReceiptRequest() got receipt %s\n",
+                receipt.toString());
+        return receipt;
+    }
+}


### PR DESCRIPTION
Add support for [Privacy Marker Transactions](https://docs.goquorum.consensys.net/en/latest/Concepts/Privacy/PrivacyMarkerTransactions/) (released in go-quorum v21.7.1).
Note that this PR builds on top of [PrivacyEnhancements PR](https://github.com/web3j/web3j-quorum/pull/54) (in the expectation that older PR would be merged to master prior to this one).

These changes mirror the changes made to web3js-quorum in [PR#24](https://github.com/ConsenSys/web3js-quorum/pull/24) and [PR#25](https://github.com/ConsenSys/web3js-quorum/pull/25).

**New API methods:**
- eth_distributePrivateTransaction
- eth_getPrivacyPrecompileAddress
- eth_getPrivateTransactionByHash
- eth_getPrivateTransactionReceipt

**Transaction receipt modification:**

Modified Transaction Receipt to include extra field:
- isPrivacyMarkerTransaction

**Retrieve contract address from private receipt:**

If contract is deployed using `ClientTransactionManager` and the transaction is a Privacy Marker, then the receipt for the inner private transaction is retrieved to obtain the contract address for participants.