### PR TITLE
Support for Quorum Extension APIs

### DIFF
--- a/src/integration-test/java/org/web3j/quorum/ExtensionRequestTest.java
+++ b/src/integration-test/java/org/web3j/quorum/ExtensionRequestTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.quorum;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import org.web3j.protocol.RequestTester;
+import org.web3j.protocol.http.HttpService;
+import org.web3j.quorum.methods.request.PrivateTransaction;
+
+public class ExtensionRequestTest extends RequestTester {
+
+    private Quorum web3j;
+
+    @Override
+    protected void initWeb3Client(HttpService httpService) {
+        web3j = Quorum.build(httpService);
+    }
+
+    @Test
+    public void testActiveExtensionList() throws Exception {
+        web3j.quorumExtensionActiveExtensionContracts().send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumExtension_activeExtensionContracts\",\"params\":[],\"id\":0}");
+    }
+
+    @Test
+    public void testApproveExtension() throws Exception {
+        web3j.quorumExtensionApproveExtension(
+                        "addressToVoteOn",
+                        true,
+                        new PrivateTransaction(
+                                "FROM",
+                                BigInteger.ONE,
+                                BigInteger.TEN,
+                                "TO",
+                                BigInteger.TEN,
+                                "DATA",
+                                "privateFrom",
+                                Arrays.asList("privateFor1", "privateFor2")))
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumExtension_approveExtension\",\"params\":[\"addressToVoteOn\",true,{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
+    }
+
+    @Test
+    public void testCancelExtension() throws Exception {
+        web3j.quorumExtensionCancelExtension(
+                        "extensionContract",
+                        new PrivateTransaction(
+                                "FROM",
+                                BigInteger.ONE,
+                                BigInteger.TEN,
+                                "TO",
+                                BigInteger.TEN,
+                                "DATA",
+                                "privateFrom",
+                                Arrays.asList("privateFor1", "privateFor2")))
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumExtension_cancelExtension\",\"params\":[\"extensionContract\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
+    }
+
+    @Test
+    public void testExtendContract() throws Exception {
+        web3j.quorumExtensionExtendContract(
+                        "toExtend",
+                        "newRecipientPtmPublicKey",
+                        "recipientAddress",
+                        new PrivateTransaction(
+                                "FROM",
+                                BigInteger.ONE,
+                                BigInteger.TEN,
+                                "TO",
+                                BigInteger.TEN,
+                                "DATA",
+                                "privateFrom",
+                                Arrays.asList("privateFor1", "privateFor2")))
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumExtension_extendContract\",\"params\":[\"toExtend\",\"newRecipientPtmPublicKey\",\"recipientAddress\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
+    }
+
+    @Test
+    public void testExtensionStatus() throws Exception {
+        web3j.quorumExtensionGetExtensionStatus(
+                        "managementContractAddress",
+                        new PrivateTransaction(
+                                "FROM",
+                                BigInteger.ONE,
+                                BigInteger.TEN,
+                                "TO",
+                                BigInteger.TEN,
+                                "DATA",
+                                "privateFrom",
+                                Arrays.asList("privateFor1", "privateFor2")))
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumExtension_getExtensionStatus\",\"params\":[\"managementContractAddress\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
+    }
+}

--- a/src/integration-test/java/org/web3j/quorum/ExtensionRequestTest.java
+++ b/src/integration-test/java/org/web3j/quorum/ExtensionRequestTest.java
@@ -100,20 +100,9 @@ public class ExtensionRequestTest extends RequestTester {
 
     @Test
     public void testExtensionStatus() throws Exception {
-        web3j.quorumExtensionGetExtensionStatus(
-                        "managementContractAddress",
-                        new PrivateTransaction(
-                                "FROM",
-                                BigInteger.ONE,
-                                BigInteger.TEN,
-                                "TO",
-                                BigInteger.TEN,
-                                "DATA",
-                                "privateFrom",
-                                Arrays.asList("privateFor1", "privateFor2")))
-                .send();
+        web3j.quorumExtensionGetExtensionStatus("managementContractAddress").send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumExtension_getExtensionStatus\",\"params\":[\"managementContractAddress\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumExtension_getExtensionStatus\",\"params\":[\"managementContractAddress\"],\"id\":0}");
     }
 }

--- a/src/integration-test/java/org/web3j/quorum/ExtensionResponseTest.java
+++ b/src/integration-test/java/org/web3j/quorum/ExtensionResponseTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.quorum;
+
+import org.junit.jupiter.api.Test;
+
+import org.web3j.protocol.ResponseTester;
+import org.web3j.quorum.methods.response.extension.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class ExtensionResponseTest extends ResponseTester {
+
+    @Test
+    public void testActiveExtensionList() {
+        buildResponse(
+                "{\n"
+                        + "  \"jsonrpc\":\"2.0\",\n"
+                        + "  \"id\":10,\n"
+                        + "  \"result\": [{\n"
+                        + "    \"managementContractAddress\":\"managementContractAddress\",\n"
+                        + "    \"contractExtended\":\"contractExtended\",\n"
+                        + "    \"creationData\":\"creationData\",\n"
+                        + "    \"initiator\":\"initiator\",\n"
+                        + "    \"recipient\":\"recipient\",\n"
+                        + "    \"recipientPtmKey\":\"recipientPtmKey\"\n"
+                        + "  }]\n"
+                        + "}");
+
+        ActiveExtensionList actExtList = deserialiseResponse(ActiveExtensionList.class);
+        assertThat(
+                actExtList.getActiveExtensionList().toString(),
+                is(
+                        "[ActiveExtensionInfo(managementContractAddress=managementContractAddress, contractExtended=contractExtended, creationData=creationData, initiator=initiator, recipient=recipient, recipientPtmKey=recipientPtmKey)]"));
+    }
+
+    @Test
+    public void testApproveExtension() {
+        buildResponse(
+                "{\n"
+                        + "  \"jsonrpc\":\"2.0\",\n"
+                        + "  \"id\":10,\n"
+                        + "  \"result\":\"result\"\n"
+                        + "}");
+
+        ApproveExtensionInfo approveExtensionInfo = deserialiseResponse(ApproveExtensionInfo.class);
+        assertThat(approveExtensionInfo.getApproveExtensionInfo(), is("result"));
+    }
+
+    @Test
+    public void testCancelExtension() {
+        buildResponse(
+                "{\n"
+                        + "  \"jsonrpc\":\"2.0\",\n"
+                        + "  \"id\":10,\n"
+                        + "  \"result\":\"result\"\n"
+                        + "}");
+
+        CancelExtensionInfo cancelExtensionInfo = deserialiseResponse(CancelExtensionInfo.class);
+        assertThat(cancelExtensionInfo.getCancelExtensionInfo(), is("result"));
+    }
+
+    @Test
+    public void testExtendContract() {
+        buildResponse(
+                "{\n"
+                        + "  \"jsonrpc\":\"2.0\",\n"
+                        + "  \"id\":10,\n"
+                        + "  \"result\":\"result\"\n"
+                        + "}");
+
+        ExtendContractInfo extendContractInfo = deserialiseResponse(ExtendContractInfo.class);
+        assertThat(extendContractInfo.getExtendContractInfo(), is("result"));
+    }
+
+    @Test
+    public void testExtensionStatus() {
+        buildResponse(
+                "{\n"
+                        + "  \"jsonrpc\":\"2.0\",\n"
+                        + "  \"id\":10,\n"
+                        + "  \"result\":\"DONE\"\n"
+                        + "}");
+
+        ExtensionStatusInfo extensionStatusInfo = deserialiseResponse(ExtensionStatusInfo.class);
+        assertThat(extensionStatusInfo.getExtensionStatus(), is("DONE"));
+    }
+}

--- a/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
+++ b/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
@@ -26,6 +26,7 @@ import org.web3j.protocol.core.methods.response.EthTransaction;
 import org.web3j.quorum.methods.request.PrivateRawTransaction;
 import org.web3j.quorum.methods.request.PrivateTransaction;
 import org.web3j.quorum.methods.response.*;
+import org.web3j.quorum.methods.response.extension.*;
 import org.web3j.quorum.methods.response.istanbul.IstanbulBlockSigners;
 import org.web3j.quorum.methods.response.istanbul.IstanbulCandidates;
 import org.web3j.quorum.methods.response.istanbul.IstanbulNodeAddress;
@@ -568,5 +569,57 @@ public class JsonRpc2_0Quorum extends JsonRpc2_0Web3j implements Quorum {
                 Arrays.asList(orgId, address, transaction),
                 web3jService,
                 ExecStatusInfo.class);
+    }
+
+    @Override
+    public Request<?, ActiveExtensionList> quorumExtensionActiveExtensionContracts() {
+        return new Request<>(
+                "quorumExtension_activeExtensionContracts",
+                Collections.emptyList(),
+                web3jService,
+                ActiveExtensionList.class);
+    }
+
+    @Override
+    public Request<?, ApproveExtensionInfo> quorumExtensionApproveExtension(
+            String addressToVoteOn, boolean vote, PrivateTransaction transaction) {
+        return new Request<>(
+                "quorumExtension_approveExtension",
+                Arrays.asList(addressToVoteOn, vote, transaction),
+                web3jService,
+                ApproveExtensionInfo.class);
+    }
+
+    @Override
+    public Request<?, CancelExtensionInfo> quorumExtensionCancelExtension(
+            String extensionContract, PrivateTransaction transaction) {
+        return new Request<>(
+                "quorumExtension_cancelExtension",
+                Arrays.asList(extensionContract, transaction),
+                web3jService,
+                CancelExtensionInfo.class);
+    }
+
+    @Override
+    public Request<?, ExtendContractInfo> quorumExtensionExtendContract(
+            String toExtend,
+            String newRecipientPtmPublicKey,
+            String recipientAddress,
+            PrivateTransaction transaction) {
+        return new Request<>(
+                "quorumExtension_extendContract",
+                Arrays.asList(toExtend, newRecipientPtmPublicKey, recipientAddress, transaction),
+                web3jService,
+                ExtendContractInfo.class);
+    }
+
+    @Override
+    public Request<?, ExtensionStatusInfo> quorumExtensionGetExtensionStatus(
+            String managementContractAddress, PrivateTransaction transaction) {
+        return new Request<>(
+                "quorumExtension_getExtensionStatus",
+                Arrays.asList(managementContractAddress, transaction),
+                web3jService,
+                ExtensionStatusInfo.class);
     }
 }

--- a/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
+++ b/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
@@ -615,10 +615,10 @@ public class JsonRpc2_0Quorum extends JsonRpc2_0Web3j implements Quorum {
 
     @Override
     public Request<?, ExtensionStatusInfo> quorumExtensionGetExtensionStatus(
-            String managementContractAddress, PrivateTransaction transaction) {
+            String managementContractAddress) {
         return new Request<>(
                 "quorumExtension_getExtensionStatus",
-                Arrays.asList(managementContractAddress, transaction),
+                Arrays.asList(managementContractAddress),
                 web3jService,
                 ExtensionStatusInfo.class);
     }

--- a/src/main/java/org/web3j/quorum/Quorum.java
+++ b/src/main/java/org/web3j/quorum/Quorum.java
@@ -22,6 +22,7 @@ import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.protocol.core.methods.response.EthTransaction;
 import org.web3j.quorum.methods.request.*;
 import org.web3j.quorum.methods.response.*;
+import org.web3j.quorum.methods.response.extension.*;
 import org.web3j.quorum.methods.response.istanbul.IstanbulBlockSigners;
 import org.web3j.quorum.methods.response.istanbul.IstanbulCandidates;
 import org.web3j.quorum.methods.response.istanbul.IstanbulNodeAddress;
@@ -199,4 +200,21 @@ public interface Quorum extends Web3j {
 
     Request<?, ExecStatusInfo> quorumPermissionApproveBlackListedAccountRecovery(
             String orgId, String address, PrivateTransaction transaction);
+
+    Request<?, ActiveExtensionList> quorumExtensionActiveExtensionContracts();
+
+    Request<?, ApproveExtensionInfo> quorumExtensionApproveExtension(
+            String addressToVoteOn, boolean vote, PrivateTransaction transaction);
+
+    Request<?, CancelExtensionInfo> quorumExtensionCancelExtension(
+            String extensionContract, PrivateTransaction transaction);
+
+    Request<?, ExtendContractInfo> quorumExtensionExtendContract(
+            String toExtend,
+            String newRecipientPtmPublicKey,
+            String recipientAddress,
+            PrivateTransaction transaction);
+
+    Request<?, ExtensionStatusInfo> quorumExtensionGetExtensionStatus(
+            String managementContractAddress, PrivateTransaction transaction);
 }

--- a/src/main/java/org/web3j/quorum/Quorum.java
+++ b/src/main/java/org/web3j/quorum/Quorum.java
@@ -216,5 +216,5 @@ public interface Quorum extends Web3j {
             PrivateTransaction transaction);
 
     Request<?, ExtensionStatusInfo> quorumExtensionGetExtensionStatus(
-            String managementContractAddress, PrivateTransaction transaction);
+            String managementContractAddress);
 }

--- a/src/main/java/org/web3j/quorum/methods/response/extension/ActiveExtensionList.java
+++ b/src/main/java/org/web3j/quorum/methods/response/extension/ActiveExtensionList.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.quorum.methods.response.extension;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.module.kotlin.KotlinModule;
+
+import org.web3j.protocol.core.Response;
+import org.web3j.quorum.extension.ActiveExtensionInfo;
+
+public class ActiveExtensionList extends Response<List<ActiveExtensionInfo>> {
+
+    public List<ActiveExtensionInfo> getActiveExtensionList() {
+        return getResult();
+    }
+
+    @Override
+    @JsonDeserialize(using = ActiveExtensionList.ResponseDeserialiser.class)
+    public void setResult(List<ActiveExtensionInfo> result) {
+        super.setResult(result);
+    }
+
+    public static class ResponseDeserialiser extends JsonDeserializer<List<ActiveExtensionInfo>> {
+        private ObjectMapper om = new ObjectMapper().registerModule(new KotlinModule());
+
+        @Override
+        public List<ActiveExtensionInfo> deserialize(
+                JsonParser jsonParser, DeserializationContext deserializationContext)
+                throws IOException {
+            List<ActiveExtensionInfo> extList = new ArrayList<>();
+            JsonToken nextToken = jsonParser.nextToken();
+
+            if (nextToken == JsonToken.START_OBJECT) {
+                Iterator<ActiveExtensionInfo> extInfoIterator =
+                        om.readValues(jsonParser, ActiveExtensionInfo.class);
+                while (extInfoIterator.hasNext()) {
+                    extList.add(extInfoIterator.next());
+                }
+                return extList;
+            } else {
+                return null;
+            }
+        }
+    }
+}

--- a/src/main/java/org/web3j/quorum/methods/response/extension/ApproveExtensionInfo.java
+++ b/src/main/java/org/web3j/quorum/methods/response/extension/ApproveExtensionInfo.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.quorum.methods.response.extension;
+
+import org.web3j.protocol.core.Response;
+
+public class ApproveExtensionInfo extends Response<String> {
+
+    public String getApproveExtensionInfo() {
+        return getResult();
+    }
+}

--- a/src/main/java/org/web3j/quorum/methods/response/extension/CancelExtensionInfo.java
+++ b/src/main/java/org/web3j/quorum/methods/response/extension/CancelExtensionInfo.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.quorum.methods.response.extension;
+
+import org.web3j.protocol.core.Response;
+
+public class CancelExtensionInfo extends Response<String> {
+
+    public String getCancelExtensionInfo() {
+        return getResult();
+    }
+}

--- a/src/main/java/org/web3j/quorum/methods/response/extension/ExtendContractInfo.java
+++ b/src/main/java/org/web3j/quorum/methods/response/extension/ExtendContractInfo.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.quorum.methods.response.extension;
+
+import org.web3j.protocol.core.Response;
+
+public class ExtendContractInfo extends Response<String> {
+
+    public String getExtendContractInfo() {
+        return getResult();
+    }
+}

--- a/src/main/java/org/web3j/quorum/methods/response/extension/ExtensionStatusInfo.java
+++ b/src/main/java/org/web3j/quorum/methods/response/extension/ExtensionStatusInfo.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.quorum.methods.response.extension;
+
+import org.web3j.protocol.core.Response;
+
+public class ExtensionStatusInfo extends Response<String> {
+
+    public String getExtensionStatus() {
+        return getResult();
+    }
+}

--- a/src/main/kotlin/org/web3j/quorum/extension/extension.kt
+++ b/src/main/kotlin/org/web3j/quorum/extension/extension.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.quorum.extension
+
+public data class ActiveExtensionInfo(
+    val managementContractAddress: String,
+    val contractExtended: String,
+    val creationData: String,
+    val initiator: String,
+    val recipient: String,
+    val recipientPtmKey: String
+)


### PR DESCRIPTION
### What does this PR do?
*Adds support for [Quorum Extension APIs](https://consensys.net/docs/goquorum/en/stable/reference/api-methods/#contract-extension-methods)*

New API methods

- quorumExtension_activeExtensionContracts
- quorumExtension_approveExtension
- quorumExtension_cancelExtension
- quorumExtension_extendContract
- quorumExtension_getExtensionStatus

### Where should the reviewer start?
*New functions added to Quorum.java and JsonRpc2_0Quorum.java
New Response types added*

### Why is it needed?
*Contract Extension is a primary use case to extend smart contracts when new nodes join the network. DApps require web3j-quorum to support this functionality*

