### PR TITLE
Adding support for new API quorumExtension_generateExtensionApprovalU…

### DIFF
--- a/src/integration-test/java/org/web3j/quorum/ExtensionRequestTest.java
+++ b/src/integration-test/java/org/web3j/quorum/ExtensionRequestTest.java
@@ -107,7 +107,7 @@ public class ExtensionRequestTest extends RequestTester {
     }
 
     @Test
-    public void testquorumExtensionGenerateExtensionApprovalUuid() throws Exception {
+    public void testQuorumExtensionGenerateExtensionApprovalUuid() throws Exception {
         web3j.quorumExtensionGenerateExtensionApprovalUuid(
                         "managementContractAddress",
                         "externalSigner",

--- a/src/integration-test/java/org/web3j/quorum/ExtensionRequestTest.java
+++ b/src/integration-test/java/org/web3j/quorum/ExtensionRequestTest.java
@@ -107,7 +107,7 @@ public class ExtensionRequestTest extends RequestTester {
     }
 
     @Test
-    public void testgenerateApproveUuid() throws Exception {
+    public void testquorumExtensionGenerateExtensionApprovalUuid() throws Exception {
         web3j.quorumExtensionGenerateExtensionApprovalUuid(
                         "managementContractAddress",
                         "externalSigner",
@@ -125,6 +125,4 @@ public class ExtensionRequestTest extends RequestTester {
         verifyResult(
                 "{\"jsonrpc\":\"2.0\",\"method\":\"quorumExtension_generateExtensionApprovalUuid\",\"params\":[\"managementContractAddress\",\"externalSigner\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
-
-
 }

--- a/src/integration-test/java/org/web3j/quorum/ExtensionRequestTest.java
+++ b/src/integration-test/java/org/web3j/quorum/ExtensionRequestTest.java
@@ -108,7 +108,7 @@ public class ExtensionRequestTest extends RequestTester {
 
     @Test
     public void testgenerateApproveUuid() throws Exception {
-        web3j.quorumExtensionGetApprovalUuid(
+        web3j.quorumExtensionGenerateExtensionApprovalUuid(
                         "managementContractAddress",
                         "externalSigner",
                         new PrivateTransaction(

--- a/src/integration-test/java/org/web3j/quorum/ExtensionRequestTest.java
+++ b/src/integration-test/java/org/web3j/quorum/ExtensionRequestTest.java
@@ -105,4 +105,26 @@ public class ExtensionRequestTest extends RequestTester {
         verifyResult(
                 "{\"jsonrpc\":\"2.0\",\"method\":\"quorumExtension_getExtensionStatus\",\"params\":[\"managementContractAddress\"],\"id\":0}");
     }
+
+    @Test
+    public void testgenerateApproveUuid() throws Exception {
+        web3j.quorumExtensionGetApprovalUuid(
+                        "managementContractAddress",
+                        "externalSigner",
+                        new PrivateTransaction(
+                                "FROM",
+                                BigInteger.ONE,
+                                BigInteger.TEN,
+                                "TO",
+                                BigInteger.TEN,
+                                "DATA",
+                                "privateFrom",
+                                Arrays.asList("privateFor1", "privateFor2")))
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumExtension_generateExtensionApprovalUuid\",\"params\":[\"managementContractAddress\",\"externalSigner\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
+    }
+
+
 }

--- a/src/integration-test/java/org/web3j/quorum/ExtensionResponseTest.java
+++ b/src/integration-test/java/org/web3j/quorum/ExtensionResponseTest.java
@@ -96,4 +96,17 @@ public class ExtensionResponseTest extends ResponseTester {
         ExtensionStatusInfo extensionStatusInfo = deserialiseResponse(ExtensionStatusInfo.class);
         assertThat(extensionStatusInfo.getExtensionStatus(), is("DONE"));
     }
+
+    @Test
+    public void testgenerateApproveUuid() {
+        buildResponse(
+                "{\n"
+                        + "  \"jsonrpc\":\"2.0\",\n"
+                        + "  \"id\":10,\n"
+                        + "  \"result\":\"UUID\"\n"
+                        + "}");
+
+        ApproveUuid approveUuid = deserialiseResponse(ApproveUuid.class);
+        assertThat(approveUuid.getApproveUuid(), is("UUID"));
+    }
 }

--- a/src/integration-test/java/org/web3j/quorum/ExtensionResponseTest.java
+++ b/src/integration-test/java/org/web3j/quorum/ExtensionResponseTest.java
@@ -98,7 +98,7 @@ public class ExtensionResponseTest extends ResponseTester {
     }
 
     @Test
-    public void testquorumExtensionGenerateExtensionApprovalUuid() {
+    public void testQuorumExtensionGenerateExtensionApprovalUuid() {
         buildResponse(
                 "{\n"
                         + "  \"jsonrpc\":\"2.0\",\n"

--- a/src/integration-test/java/org/web3j/quorum/ExtensionResponseTest.java
+++ b/src/integration-test/java/org/web3j/quorum/ExtensionResponseTest.java
@@ -98,7 +98,7 @@ public class ExtensionResponseTest extends ResponseTester {
     }
 
     @Test
-    public void testgquorumExtensionGenerateExtensionApprovalUuid() {
+    public void testquorumExtensionGenerateExtensionApprovalUuid() {
         buildResponse(
                 "{\n"
                         + "  \"jsonrpc\":\"2.0\",\n"

--- a/src/integration-test/java/org/web3j/quorum/ExtensionResponseTest.java
+++ b/src/integration-test/java/org/web3j/quorum/ExtensionResponseTest.java
@@ -98,7 +98,7 @@ public class ExtensionResponseTest extends ResponseTester {
     }
 
     @Test
-    public void testgenerateApproveUuid() {
+    public void testgquorumExtensionGenerateExtensionApprovalUuid() {
         buildResponse(
                 "{\n"
                         + "  \"jsonrpc\":\"2.0\",\n"
@@ -106,7 +106,8 @@ public class ExtensionResponseTest extends ResponseTester {
                         + "  \"result\":\"UUID\"\n"
                         + "}");
 
-        ApproveUuid approveUuid = deserialiseResponse(ApproveUuid.class);
-        assertThat(approveUuid.getApproveUuid(), is("UUID"));
+        ExtensionApprovalUuid extensionApprovalUuid =
+                deserialiseResponse(ExtensionApprovalUuid.class);
+        assertThat(extensionApprovalUuid.getExtensionApprovalUuid(), is("UUID"));
     }
 }

--- a/src/integration-test/java/org/web3j/quorum/PermissionRequestTest.java
+++ b/src/integration-test/java/org/web3j/quorum/PermissionRequestTest.java
@@ -80,7 +80,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_addOrg\",\"params\":[\"orgId\",\"url\",\"address\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_addOrg\",\"params\":[\"orgId\",\"url\",\"address\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -101,7 +101,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_approveOrg\",\"params\":[\"orgId\",\"url\",\"address\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_approveOrg\",\"params\":[\"orgId\",\"url\",\"address\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -122,7 +122,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_addSubOrg\",\"params\":[\"pOrgId\",\"orgId\",\"url\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_addSubOrg\",\"params\":[\"pOrgId\",\"orgId\",\"url\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -142,7 +142,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_updateOrgStatus\",\"params\":[\"orgId\",1,{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_updateOrgStatus\",\"params\":[\"orgId\",1,{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -162,7 +162,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_approveOrgStatus\",\"params\":[\"orgId\",1,{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_approveOrgStatus\",\"params\":[\"orgId\",1,{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -182,7 +182,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_addNode\",\"params\":[\"orgId\",\"url\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_addNode\",\"params\":[\"orgId\",\"url\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -203,7 +203,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_updateNodeStatus\",\"params\":[\"orgId\",\"url\",1,{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_updateNodeStatus\",\"params\":[\"orgId\",\"url\",1,{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -224,7 +224,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_assignAdminRole\",\"params\":[\"orgId\",\"address\",\"roleid\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_assignAdminRole\",\"params\":[\"orgId\",\"address\",\"roleid\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -244,7 +244,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_approveAdminRole\",\"params\":[\"orgId\",\"address\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_approveAdminRole\",\"params\":[\"orgId\",\"address\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -267,7 +267,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_addNewRole\",\"params\":[\"orgId\",\"roleId\",1,true,true,{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_addNewRole\",\"params\":[\"orgId\",\"roleId\",1,true,true,{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -287,7 +287,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_removeRole\",\"params\":[\"orgId\",\"roleId\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_removeRole\",\"params\":[\"orgId\",\"roleId\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -308,7 +308,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_addAccountToOrg\",\"params\":[\"address\",\"orgId\",\"roleId\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_addAccountToOrg\",\"params\":[\"address\",\"orgId\",\"roleId\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -329,7 +329,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_changeAccountRole\",\"params\":[\"address\",\"orgId\",\"roleId\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_changeAccountRole\",\"params\":[\"address\",\"orgId\",\"roleId\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -350,7 +350,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_updateAccountStatus\",\"params\":[\"orgId\",\"address\",1,{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_updateAccountStatus\",\"params\":[\"orgId\",\"address\",1,{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -378,7 +378,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_recoverBlackListedNode\",\"params\":[\"orgId\",\"enodeId\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_recoverBlackListedNode\",\"params\":[\"orgId\",\"enodeId\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -398,7 +398,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_approveBlackListedNodeRecovery\",\"params\":[\"orgId\",\"enodeId\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_approveBlackListedNodeRecovery\",\"params\":[\"orgId\",\"enodeId\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -418,7 +418,7 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_recoverBlackListedAccount\",\"params\":[\"orgId\",\"address\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_recoverBlackListedAccount\",\"params\":[\"orgId\",\"address\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 
     @Test
@@ -438,6 +438,6 @@ public class PermissionRequestTest extends RequestTester {
                 .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_approveBlackListedAccountRecovery\",\"params\":[\"orgId\",\"address\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"]}],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"quorumPermission_approveBlackListedAccountRecovery\",\"params\":[\"orgId\",\"address\",{\"from\":\"FROM\",\"to\":\"TO\",\"gas\":\"0xa\",\"value\":\"0xa\",\"data\":\"0xDATA\",\"nonce\":\"0x1\",\"privateFrom\":\"privateFrom\",\"privateFor\":[\"privateFor1\",\"privateFor2\"],\"privacyFlag\":0}],\"id\":0}");
     }
 }

--- a/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
+++ b/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
@@ -624,12 +624,12 @@ public class JsonRpc2_0Quorum extends JsonRpc2_0Web3j implements Quorum {
     }
 
     @Override
-    public Request<?, ApproveUuid> quorumExtensionGenerateExtensionApprovalUuid(
+    public Request<?, ExtensionApprovalUuid> quorumExtensionGenerateExtensionApprovalUuid(
             String addressToVoteOn, String externalSignerAddress, PrivateTransaction transaction) {
         return new Request<>(
                 "quorumExtension_generateExtensionApprovalUuid",
                 Arrays.asList(addressToVoteOn, externalSignerAddress, transaction),
                 web3jService,
-                ApproveUuid.class);
+                ExtensionApprovalUuid.class);
     }
 }

--- a/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
+++ b/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
@@ -625,9 +625,7 @@ public class JsonRpc2_0Quorum extends JsonRpc2_0Web3j implements Quorum {
 
     @Override
     public Request<?, ApproveUuid> quorumExtensionGenerateExtensionApprovalUuid(
-            String addressToVoteOn,
-            String externalSignerAddress,
-            PrivateTransaction transaction) {
+            String addressToVoteOn, String externalSignerAddress, PrivateTransaction transaction) {
         return new Request<>(
                 "quorumExtension_generateExtensionApprovalUuid",
                 Arrays.asList(addressToVoteOn, externalSignerAddress, transaction),

--- a/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
+++ b/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
@@ -622,4 +622,16 @@ public class JsonRpc2_0Quorum extends JsonRpc2_0Web3j implements Quorum {
                 web3jService,
                 ExtensionStatusInfo.class);
     }
+
+    @Override
+    public Request<?, ApproveUuid> quorumExtensionGetApprovalUuid(
+            String addressToVoteOn,
+            String externalSignerAddress,
+            PrivateTransaction transaction) {
+        return new Request<>(
+                "quorumExtension_generateExtensionApprovalUuid",
+                Arrays.asList(addressToVoteOn, externalSignerAddress, transaction),
+                web3jService,
+                ApproveUuid.class);
+    }
 }

--- a/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
+++ b/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
@@ -624,7 +624,7 @@ public class JsonRpc2_0Quorum extends JsonRpc2_0Web3j implements Quorum {
     }
 
     @Override
-    public Request<?, ApproveUuid> quorumExtensionGetApprovalUuid(
+    public Request<?, ApproveUuid> quorumExtensionGenerateExtensionApprovalUuid(
             String addressToVoteOn,
             String externalSignerAddress,
             PrivateTransaction transaction) {

--- a/src/main/java/org/web3j/quorum/Quorum.java
+++ b/src/main/java/org/web3j/quorum/Quorum.java
@@ -217,4 +217,9 @@ public interface Quorum extends Web3j {
 
     Request<?, ExtensionStatusInfo> quorumExtensionGetExtensionStatus(
             String managementContractAddress);
+
+    Request<?, ApproveUuid> quorumExtensionGetApprovalUuid(
+            String addressToVoteOn,
+            String externalSignerAddress,
+            PrivateTransaction transaction);
 }

--- a/src/main/java/org/web3j/quorum/Quorum.java
+++ b/src/main/java/org/web3j/quorum/Quorum.java
@@ -218,6 +218,6 @@ public interface Quorum extends Web3j {
     Request<?, ExtensionStatusInfo> quorumExtensionGetExtensionStatus(
             String managementContractAddress);
 
-    Request<?, ApproveUuid> quorumExtensionGenerateExtensionApprovalUuid(
+    Request<?, ExtensionApprovalUuid> quorumExtensionGenerateExtensionApprovalUuid(
             String addressToVoteOn, String externalSignerAddress, PrivateTransaction transaction);
 }

--- a/src/main/java/org/web3j/quorum/Quorum.java
+++ b/src/main/java/org/web3j/quorum/Quorum.java
@@ -218,7 +218,7 @@ public interface Quorum extends Web3j {
     Request<?, ExtensionStatusInfo> quorumExtensionGetExtensionStatus(
             String managementContractAddress);
 
-    Request<?, ApproveUuid> quorumExtensionGetApprovalUuid(
+    Request<?, ApproveUuid> quorumExtensionGenerateExtensionApprovalUuid(
             String addressToVoteOn,
             String externalSignerAddress,
             PrivateTransaction transaction);

--- a/src/main/java/org/web3j/quorum/Quorum.java
+++ b/src/main/java/org/web3j/quorum/Quorum.java
@@ -219,7 +219,5 @@ public interface Quorum extends Web3j {
             String managementContractAddress);
 
     Request<?, ApproveUuid> quorumExtensionGenerateExtensionApprovalUuid(
-            String addressToVoteOn,
-            String externalSignerAddress,
-            PrivateTransaction transaction);
+            String addressToVoteOn, String externalSignerAddress, PrivateTransaction transaction);
 }

--- a/src/main/java/org/web3j/quorum/methods/response/extension/ApproveUuid.java
+++ b/src/main/java/org/web3j/quorum/methods/response/extension/ApproveUuid.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.quorum.methods.response.extension;
+
+import org.web3j.protocol.core.Response;
+
+public class ApproveUuid extends Response<String> {
+
+    public String getApproveUuid() {
+        return getResult();
+    }
+}

--- a/src/main/java/org/web3j/quorum/methods/response/extension/ExtensionApprovalUuid.java
+++ b/src/main/java/org/web3j/quorum/methods/response/extension/ExtensionApprovalUuid.java
@@ -14,9 +14,9 @@ package org.web3j.quorum.methods.response.extension;
 
 import org.web3j.protocol.core.Response;
 
-public class ApproveUuid extends Response<String> {
+public class ExtensionApprovalUuid extends Response<String> {
 
-    public String getApproveUuid() {
+    public String getExtensionApprovalUuid() {
         return getResult();
     }
 }


### PR DESCRIPTION
To allow contract extension approval using an externally owned account a new API was introduced. Please refer to this PR request that was recently merged [PR](https://github.com/ConsenSys/quorum/pull/1613)

### What does this PR do?
This PR introduces support to call the new API method "quorumExtension_generateExtensionApprovalUuid" 
All the required intergrations tests are in place and I have also fixed the broken integration tests on **PermissionRequestTest.java**

### Where should the reviewer start?
Refer to the function "**quorumExtensionGetApprovalUuid**" in src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java 
Also refer to the original PR in GoQuorum [PR](https://github.com/ConsenSys/quorum/pull/1613)

### Why is it needed?
To support invocation of the new API

